### PR TITLE
Use meta instead of context in log handler

### DIFF
--- a/logdna/logdna.py
+++ b/logdna/logdna.py
@@ -77,11 +77,11 @@ class LogDNAHandler(logging.Handler):
             message['hostname'] = opts['hostname']
         if 'timestamp' in opts:
             message['timestamp'] = opts['timestamp']
-        if 'context' in opts:
+        if 'meta' in opts:
             if self.index_meta:
-                message['meta'] = opts['context']
+                message['meta'] = opts['meta']
             else:
-                message['meta'] = json.dumps(opts['context'])
+                message['meta'] = json.dumps(opts['meta'])
 
         self.bufferLog(message)
 


### PR DESCRIPTION
It looks like `context` was refactored to `meta` in docs https://github.com/logdna/python/commit/038a935e336c9ef9866764675c1a044633dccb71 , but actual code still references old name