### PR TITLE
Fixing TypeError in error printing

### DIFF
--- a/logdna/logdna.py
+++ b/logdna/logdna.py
@@ -33,7 +33,7 @@ class LogDNAHandler(logging.Handler):
         if message and message['line']:
             if self.max_length and len(message['line']) > defaults['MAX_LINE_LENGTH']:
                 message['line'] = message['line'][:defaults['MAX_LINE_LENGTH']] + ' (cut off, too long...)'
-                print('Line was longer than ' + defaults['MAX_LINE_LENGTH'] + ' chars and was truncated.')
+                print('Line was longer than {0} chars and was truncated.'.format(defaults['MAX_LINE_LENGTH'])
 
             self.bufByteLength += sys.getsizeof(message)
             self.buf.append(message)


### PR DESCRIPTION
If message is too long then code was trying to concatenate `str` and `int` which throws error.

It would be even better if that line could be removed completely.  I don't see reason for having `print` in library