### PR TITLE
Allow logging format message 

### DIFF
--- a/logdna/logdna.py
+++ b/logdna/logdna.py
@@ -62,6 +62,7 @@ class LogDNAHandler(logging.Handler):
             logger.error('Error in request to LogDNA: ' + str(e))
 
     def emit(self, record):
+        msg = self.format(record)
         record = record.__dict__
         opts = {}
         if 'args' in record:
@@ -69,7 +70,7 @@ class LogDNAHandler(logging.Handler):
         message = {
             'hostname' : self.hostname,
             'timestamp': int(time.time()),
-            'line': record['msg'],
+            'line': msg,
             'level': record['levelname'] or self.level,
             'app': self.app or record['module']
         }


### PR DESCRIPTION
so we are good with logging docs

This change allows usage of `log.info('abc %s', 'xyz', ...)` while logging data.
