### PR TITLE
Flush logger buffer prior to closing handler

### DIFF
--- a/logdna/logdna.py
+++ b/logdna/logdna.py
@@ -90,4 +90,12 @@ class LogDNAHandler(logging.Handler):
         self.bufferLog(message)
 
     def close(self):
-        logging.Handler.close(self)
+        """
+        Close the log handler.
+        
+        Make sure that the log handler has attempted to flush the log buffer before closing.
+        """
+        try:
+            self.flush()
+        finally:
+            logging.Handler.close(self)


### PR DESCRIPTION
When an application terminates any outstanding logs in the log handler buffer will be lost.  Make sure that the log buffer is flushed prior to being closed.