### PR TITLE
feat(meta): Python log info in meta object

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ The default env passed along with every log sent through this instance.
 
 The default hostname passed along with every log sent through this instance.
 
+##### include_standard_meta
+
+* _Optional_
+* Type: `Boolean`
+* Default: `False`
+
+Python [`LogRecord` objects](https://docs.python.org/2/library/logging.html#logrecord-objects) include language-specific information that may be useful metadata in logs.  Setting `include_standard_meta` to `True` will automatically populate meta objects with `name`, `pathname`, and `lineno` from the `LogRecord`.  See [`LogRecord` docs](https://docs.python.org/2/library/logging.html#logrecord-objects) for more detail on these values.
+
+
 ##### index_meta
 
 * _Optional_


### PR DESCRIPTION
Overview
--------

Python log records have some useful data (other than just the message) which can be very helpful as metadata.  For example, the `name` of the logger is useful to know which parts of an app logs are coming from.  Including `pathname` and `lineno` tell us exactly where logs are coming from and  aid debugging efforts.

This PR adds an option to include these helpful values in `meta` of logdna messages.

Changes
-------

- New option `include_standard_meta` which include py log data
    - Includes `name`, `pathname`, and `lineno`