### PR TITLE
Specify license in setup.py for PyPi index

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setuptools.setup(
   description = 'A python package for sending logs to LogDNA',
   author = 'Answerbook Inc.',
   author_email = 'help@logdna.com',
+  license = 'MIT',
   url = 'https://github.com/logdna/python',
   download_url = 'https://github.com/logdna/python/tarball/1.2.7',
   keywords = ['logdna', 'logging', 'logs', 'python', 'logdna.com', 'logger'],


### PR DESCRIPTION
The [`logdna`](https://pypi.org/project/logdna/) entry in the Python Package Index shows up without a license because none is specified in setup.py.

This patch adds the MIT license identifier to setup.py.