### PR TITLE
Allow setting of the logdna url

### DIFF
--- a/logdna/logdna.py
+++ b/logdna/logdna.py
@@ -37,7 +37,7 @@ class LogDNAHandler(logging.Handler):
         if 'include_standard_meta' in options:
             self.include_standard_meta = options['include_standard_meta']
         self.flushLimit = defaults['FLUSH_BYTE_LIMIT']
-        self.url = defaults['LOGDNA_URL']
+        self.url = options.get('url', defaults['LOGDNA_URL'])
         self.bufByteLength = 0
         self.flusher = None
         self.lock = threading.RLock()
@@ -79,7 +79,7 @@ class LogDNAHandler(logging.Handler):
                     self.flusher.start()
             else:
                 resp = requests.post(
-                    url=defaults['LOGDNA_URL'],
+                    url=self.url,
                     json=data,
                     auth=('user', self.key),
                     params={


### PR DESCRIPTION
In order to use this code with other hosted versions of logdna, such
as IBM Cloud, we need the ability to set the api url. This is done via
an additional parameter in options.