### PR TITLE
Change default timeout to 1s instead of 30s

### DIFF
--- a/logdna/configs.py
+++ b/logdna/configs.py
@@ -1,8 +1,8 @@
 defaults = {
     'CONTENT_TYPE': 'application/json; charset=UTF-8',
-    'DEFAULT_REQUEST_TIMEOUT': 30000,
+    'DEFAULT_REQUEST_TIMEOUT': 1000,
     'MS_IN_A_DAY': 86400000,
-    'MAX_REQUEST_TIMEOUT': 30,
+    'MAX_REQUEST_TIMEOUT': 1,
     'MAX_LINE_LENGTH': 32000,
     'MAX_INPUT_LENGTH': 32,
     'FLUSH_INTERVAL': 5,


### PR DESCRIPTION
This `request_timeout` is configurable via `options` and [gets passed directly as the timeout for `requests.post` to the ingestion endpoint].(https://github.com/logdna/python/blob/master/logdna/logdna.py#L91)
 - Most users of this library, ourselves included, will probably not change these defaults, so they should be set to something sensible. There's almost never a reason why a `POST` to the ingestion endpoint should ever wait this long.
 - During periods of degraded LogDNA ingestion performance such as on May 13, 2019 and 15, 2019, all logging statements effectively block for up to 30s using the defaults.
 - Other logging libraries we use such as [Sentry, use a 1s default timeout](https://docs.sentry.io/clients/python/transports/), which under normal circumstances should be more than enough

![Screen Shot 2019-05-16 at 1 18 27 PM](https://user-images.githubusercontent.com/177059/57884384-563fa480-77dd-11e9-9a89-534e11846aed.png)
