### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 ---
 
-* **[Install](#install)**
+* **[Installation](#installation)**
 * **[Setup](#setup)**
 * **[Usage](#usage)**
 * **[API](#api)**
 * **[License](#license)**
 
 
-## Install
+## Installation
 
 ```bash
 $ pip install logdna
@@ -36,14 +36,14 @@ options = {
   'mac': 'C0:FF:EE:C0:FF:EE'
 }
 
-# Defaults to false, when true ensures meta object will be searchable
+# Defaults to False; when True meta objects are searchable
 options['index_meta'] = True
 
 test = LogDNAHandler(key, options)
 
 log.addHandler(test)
 
-log.warn("Warning message", {'app': 'bloop'})
+log.warning("Warning message", {'app': 'bloop'})
 log.info("Info message")
 
 ```
@@ -70,17 +70,17 @@ log.info('My Sample Log Line', { 'level': 'MyCustomLevel' })
 # Include an App name with this specific log
 log.info('My Sample Log Line', { 'level': 'Warn', 'app': 'myAppName'})
 
-# Pass any associated objects along as metadata
+# Pass associated objects along as metadata
 meta = {
     'foo': 'bar',
     'nested': {
-      'nest1': 'nested text'
+        'nest1': 'nested text'
     }
 }
 
 opts = {
-  'level': 'warn',
-  'meta': meta
+    'level': 'warn',
+    'meta': meta
 }
 
 log.info('My Sample Log Line', opts)
@@ -170,7 +170,7 @@ The default hostname passed along with every log sent through this instance.
 * Type: `Boolean`
 * Default: `False`
 
-Python [`LogRecord` objects](https://docs.python.org/2/library/logging.html#logrecord-objects) include language-specific information that may be useful metadata in logs.  Setting `include_standard_meta` to `True` will automatically populate meta objects with `name`, `pathname`, and `lineno` from the `LogRecord`.  See [`LogRecord` docs](https://docs.python.org/2/library/logging.html#logrecord-objects) for more detail on these values.
+Python [`LogRecord` objects](https://docs.python.org/2/library/logging.html#logrecord-objects) includes language-specific information that may be useful metadata in logs.  Setting `include_standard_meta` to `True` automatically populates meta objects with `name`, `pathname`, and `lineno` from the `LogRecord`.  See [`LogRecord` docs](https://docs.python.org/2/library/logging.html#logrecord-objects) for more details about these values.
 
 
 ##### index_meta
@@ -179,11 +179,11 @@ Python [`LogRecord` objects](https://docs.python.org/2/library/logging.html#logr
 * Type: `Boolean`
 * Default: `False`
 
-We allow meta objects to be passed with each line. By default these meta objects will be stringified and will not be searchable, but will be displayed for informational purposes.
+We allow meta objects to be passed with each line. By default these meta objects are stringified and not searchable, and are only displayed for informational purposes.
 
-If this option is turned to true then meta objects will be parsed and will be searchable up to three levels deep. Any fields deeper than three levels will be stringified and cannot be searched.
+If this option is set to True then meta objects are parsed and searchable up to three levels deep. Any fields deeper than three levels are stringified and cannot be searched.
 
-*WARNING* When this option is true, your metadata objects across all types of log messages MUST have consistent types or the metadata object may not be parsed properly!
+*WARNING* If this option is True, your metadata objects MUST have consistent types across all log messages or the metadata object may not be parsed properly.
 
 
 ##### level
@@ -200,10 +200,10 @@ The default level passed along with every log sent through this instance.
 
 * _Optional_
 * Type: `String` or `Boolean`
-* Default: `true`
+* Default: `True`
 * Values: False or any level
 
-The verbosity of the log statements in each failure.
+Sets the verbosity of log statements for failures.
 
 ##### request_timeout
 
@@ -211,8 +211,7 @@ The verbosity of the log statements in each failure.
 * Type: `int`
 * Default: `30000`
 
-The amount of time the request should wait for LogDNA to respond before timing out.
-
+The amount of time (in ms) the request should wait for LogDNA to respond before timing out.
 
 ##### tags
 
@@ -228,7 +227,7 @@ List of tags used to dynamically group hosts.  More information on tags is avail
 * Type: `String`
 * Default: `'https://logs.logdna.com/logs/ingest'`
 
-The custom ingestion endpoint to stream the log lines into.
+A custom ingestion endpoint to stream log lines into.
 
 ### log(line, [options])
 ---
@@ -239,7 +238,7 @@ The custom ingestion endpoint to stream the log lines into.
 * Default: `''`
 * Max Length: `32000`
 
-The line which will be sent to the LogDNA system.
+The log line to be sent to LogDNA.
 
 #### options
 
@@ -288,8 +287,8 @@ values that are not JSON serializable will be removed and the respective keys wi
 * Type: `Boolean`
 * Default: `False`
 
-We allow meta objects to be passed with each line. By default these meta objects will be stringified and will not be searchable,
-but will be displayed for informational purposes.
+We allow meta objects to be passed with each line. By default these meta objects will be stringified and will not be
+searchable, but will be displayed for informational purposes.
 
 If this option is turned to true then meta objects will be parsed and will be searchable up to three levels deep. Any fields deeper than three levels will be stringified and cannot be searched.
 
@@ -300,7 +299,7 @@ If this option is turned to true then meta objects will be parsed and will be se
 * _Optional_
 * Default: `time.time()`
 
-A timestamp in ms, must be within one day otherwise it will be dropped and time.time() will be used in its place.
+The time in seconds since the epoch to use for the log timestamp. It must be within one day or current time - if it is not, it is ignored and time.time() is used in its place.
 
 
 ## License


### PR DESCRIPTION
Some updates the README. Mostly minor language changes, but also:
- Change examples to use `warning` not `warn`; the latter is deprecated in both Python 2 and 3.
- Be consistent with `False` and `True` capitalization to match Python type
- Fix code examples to use PEP8 indent consistently
- Fix doc for `timestamp` - it's in sec, not ms. Or at least `time.time()` returns secs from epoch, not ms.
-