### PR TITLE
fix(opts): repair logging options for each call

### DIFF
--- a/logdna/logdna.py
+++ b/logdna/logdna.py
@@ -238,6 +238,15 @@ class LogDNAHandler(logging.Handler):
                     message['meta'][key] = record[key]
 
         message['meta'] = sanitize_meta(message['meta'], self.index_meta)
+
+        opts = {}
+        if 'args' in record and not isinstance(record['args'], tuple):
+            opts = record['args']
+
+        for key in ['app', 'env', 'hostname', 'level', 'timestamp']:
+            if key in opts:
+                message[key] = opts[key]
+
         self.buffer_log(message)
 
     def close(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ branch = true
 source = ["logdna"]
 
 [tool.coverage.report]
-fail_under = 75
+fail_under = 76
 show_missing = true
 
 [tool.coverage.json]

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -10,16 +10,23 @@ expectedLines = []
 LOGDNA_API_KEY = '< YOUR INGESTION KEY HERE >'
 logger = logging.getLogger('logdna')
 logger.setLevel(logging.INFO)
+sample_args = {
+    'app': 'differentTest',
+    'level': 'debug',
+    'hostname': 'differentHost',
+    'env': 'differentEnv'
+}
 sample_record = logging.LogRecord('test', logging.INFO, 'test', 5,
-                                  'Something to test', '', '', '', '')
+                                  'Something to test', [sample_args], '', '',
+                                  '')
 sample_message = {
     'line': 'Something to test',
-    'hostname': 'localhost',
-    'level': 'INFO',
-    'app': 'test',
-    'env': '',
+    'hostname': 'differentHost',
+    'level': 'debug',
+    'app': 'differentTest',
+    'env': 'differentEnv',
     'meta': {
-        'args': '',
+        'args': sample_args,
         'name': 'test',
         'pathname': 'test',
         'lineno': 5


### PR DESCRIPTION
**fix(opts): repair logging options for each call**

Replacing back [this section](https://github.com/logdna/python/pull/70/files#diff-d98932f491dbf58581e648d2178063e919d9c1c80b58afa5e47bdc88c25211caL150-L184) which was removed in #70 

Semver: patch

---
**test(opts): test call-specific opts**

Semver: patch