### PR TITLE
fix: Make flush thread a daemon thread to prevent shutdown hang

### DIFF
--- a/logdna/logdna.py
+++ b/logdna/logdna.py
@@ -78,8 +78,8 @@ class LogDNAHandler(logging.Handler):
 
         # Start the flusher
         self.flusher_stopped = threading.Event()
-        self.flusher = threading.Timer(
-            self.flush_interval_secs, self.flush_timer_worker)
+        self.flusher = threading.Thread(
+            target=self.flush_timer_worker, daemon=True)
         self.flusher.start()
 
     def flush_timer_worker(self):
@@ -93,7 +93,7 @@ class LogDNAHandler(logging.Handler):
     def close_flusher(self):
         if self.flusher:
             self.flusher_stopped.set()
-            self.flusher.cancel()
+            self.flusher.join()
             self.flusher = None
 
     def buffer_log(self, message):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -320,6 +320,11 @@ class LogDNAHandlerTest(unittest.TestCase):
         self.assertEqual(len(received), num_logs)
         self.assertEquals(set(received), set(range(num_logs)))
 
+    def test_when_handlerShutDown_then_handlerDoesNotHang(self):
+        handler = LogDNAHandler(LOGDNA_API_KEY, sample_options)
+        self.assertIsNotNone(handler)
+        # Do nothing. This test should pass by virtue of not hanging.
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Convert the flush thread from a `threading.Timer` to a regular `threading.Thread` with `daemon=True`. Daemon threads don't prevent the application from [gracefully shutting down](https://docs.python.org/3/library/threading.html#thread-objects).

>A thread can be flagged as a “daemon thread”. The significance of this flag is that the entire Python program exits when only daemon threads are left. The initial value is inherited from the creating thread. The flag can be set through the [daemon](https://docs.python.org/3/library/threading.html#threading.Thread.daemon) property or the daemon constructor argument.