### PR TITLE
fix: Remove Thread/event to fix Django regression

### DIFF
--- a/logdna/logdna.py
+++ b/logdna/logdna.py
@@ -76,24 +76,17 @@ class LogDNAHandler(logging.Handler):
         self.setLevel(logging.DEBUG)
         self.lock = threading.RLock()
 
-        # Start the flusher
-        self.flusher_stopped = threading.Event()
-        self.flusher = threading.Thread(
-            target=self.flush_timer_worker, daemon=True)
-        self.flusher.start()
+        self.flusher = None
 
-    def flush_timer_worker(self):
-        while not self.flusher_stopped.wait(self.flush_interval_secs):
-            try:
-                self.flush()
-            except Exception as e:
-                self.internalLogger.exception(
-                    f'Error in flush_timer_worker: {e}')
+    def start_flusher(self):
+        if not self.flusher:
+            self.flusher = threading.Timer(
+                self.flush_interval_secs, self.flush)
+            self.flusher.start()
 
     def close_flusher(self):
         if self.flusher:
-            self.flusher_stopped.set()
-            self.flusher.join()
+            self.flusher.cancel()
             self.flusher = None
 
     def buffer_log(self, message):
@@ -119,7 +112,10 @@ class LogDNAHandler(logging.Handler):
                         self.buf_retention_limit)
 
                 if self.buf_size >= self.flush_limit:
+                    self.close_flusher()
                     self.flush()
+                else:
+                    self.start_flusher()
             except Exception as e:
                 self.internalLogger.exception(f'Error in buffer_log_sync: {e}')
             finally:
@@ -143,13 +139,15 @@ class LogDNAHandler(logging.Handler):
         local_buf = []
         if self.lock.acquire(blocking=should_block):
             if not self.buf:
+                self.close_flusher()
                 self.lock.release()
                 return
 
-            if self.buf:
-                local_buf = self.buf.copy()
-                self.buf.clear()
-                self.buf_size = 0
+            local_buf = self.buf.copy()
+            self.buf.clear()
+            self.buf_size = 0
+            if local_buf:
+                self.close_flusher()
             self.lock.release()
 
         if local_buf:
@@ -304,10 +302,10 @@ class LogDNAHandler(logging.Handler):
             'line': msg,
             'level': record['levelname'] or self.loglevel,
             'app': self.app or record['module'],
-            'env': self.env
+            'env': self.env,
+            'meta': {}
         }
 
-        message['meta'] = {}
         for key in self.custom_fields:
             if key in record:
                 if isinstance(record[key], tuple):


### PR DESCRIPTION
Due to the nature in which some third party libraries / frameworks (such as Django) will instantiate and close loggers multiple times between application startup / shutdown, revert a small portion of the recent changes to return to the pattern where the flusher can be started / stopped, based on the condition of the buffer and whether or not there is buffered data. This has been tested against the previous data loss issue and is verified to still ensure that 100% of buffered data is synced.

WIP: unit test in-progress